### PR TITLE
Fixed unused Results with try operator (fix #6)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let folder = if cli.folder.is_none() { String::from(".") } else { cli.folder.unwrap() };
 
-    wrapper::rip_grep_wrapper(&mut terminal, cli.search_term, folder);
+    wrapper::rip_grep_wrapper(&mut terminal, cli.search_term, folder)?;
 
     disable_raw_mode()?;
     terminal.show_cursor()?;

--- a/src/ui/sub_search.rs
+++ b/src/ui/sub_search.rs
@@ -32,7 +32,7 @@ pub fn render_sub_search<'a>(_rip_grep_command: String, subchild_search: String)
     sub_search
 }
 
-pub fn action_sub_search(terminal: &mut Terminal<CrosstermBackend<Stdout>>, file_name_matches: String, app: &mut App, key: KeyEvent) {
+pub fn action_sub_search(terminal: &mut Terminal<CrosstermBackend<Stdout>>, file_name_matches: String, app: &mut App, key: KeyEvent) -> Result<(), Box<dyn std::error::Error>> {
     match app.get_input_mode() {
         InputMode::Normal => {
             match key.code {
@@ -42,12 +42,12 @@ pub fn action_sub_search(terminal: &mut Terminal<CrosstermBackend<Stdout>>, file
         },
         InputMode::Editing => {
             match key.code {
-                KeyCode::Enter => { rip_grep_wrapper(terminal, app.subchild_search.clone(), file_name_matches); app.set_input_mode(InputMode::Normal); }
+                KeyCode::Enter => { rip_grep_wrapper(terminal, app.subchild_search.clone(), file_name_matches)?; app.set_input_mode(InputMode::Normal); }
                 KeyCode::Char(c) => { app.subchild_search.push(c); }
                 KeyCode::Backspace => { app.subchild_search.pop(); },
                 _ => {}
             }
         }
-    }
+    }; Ok(())
 }
 

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -143,7 +143,7 @@ pub fn rip_grep_wrapper(terminal: &mut Terminal<CrosstermBackend<Stdout>>, searc
                     action_nodes(&mut rip_grep, &mut app, key, &mut node_list_state);
                 },
                 MenuItem::SubSearch => {
-                    action_sub_search(terminal, rip_grep.get_file_name_matches(), &mut app, key);
+                    action_sub_search(terminal, rip_grep.get_file_name_matches(), &mut app, key)?;
                 },
                 _ => {
                     match key.code {


### PR DESCRIPTION
I opted to use the try operator (`?`) to handle the results since that was the way the errors were handled before the refactor (fe39088).