### PR TITLE
Optimization on spanning more context inside a specific file node.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let folder = if cli.folder.is_none() { String::from(".") } else { cli.folder.unwrap() };
 
-    wrapper::rip_grep_wrapper(&mut terminal, cli.search_term, folder)?;
+    wrapper::explorer_wrapper(&mut terminal, cli.search_term, folder)?;
 
     disable_raw_mode()?;
     terminal.show_cursor()?;

--- a/src/rip_grep/mod.rs
+++ b/src/rip_grep/mod.rs
@@ -96,21 +96,22 @@ impl RipGrep {
         }
     }
 
+    fn rg_args(&self) -> String {
+        let (search_term, after_context, before_context, folder) = (&self.search_term, &self.after_context, &self.before_context, &self.folder);
+        format!("{search_term} --json -A {after_context} -B {before_context} {folder}")
+    }
+
     fn run(&mut self) {
         self.search_term = self.search_term_buffer.clone();
-        // let args = format!("{} --json", self.search_term);
-        // let search_term = &self.search_term;
-        let (search_term, after_context, before_context, folder) = (&self.search_term, &self.after_context, &self.before_context, &self.folder);
-        // let args = format!("{search_term} --json");
-        let args = format!("{search_term} --json -A {after_context} -B {before_context} {folder}");
+        let args = self.rg_args();
         let res = Self::launch_rg(args);
         match res {
             Some(res) => {
                 let res = res.split("\n").collect::<Vec<&str>>();
-                self.nodes = Nodes::new(res, *after_context, *before_context);
+                self.nodes = Nodes::new(res, self.after_context, self.before_context);
             },
             None => {
-                self.nodes = Nodes::new(vec![], *after_context, *before_context)
+                self.nodes = Nodes::new(vec![], self.after_context, self.before_context)
             }
         }
     }

--- a/src/rip_grep/mod.rs
+++ b/src/rip_grep/mod.rs
@@ -42,8 +42,7 @@ impl Explorer {
 
     pub fn update_context(&mut self, i: usize, delta: isize) {
         let n: &mut Node = self.nodes.0.get_mut(i).unwrap();
-        // n.update_context(&self, delta);
-        n.update_context();
+        n.update_context(&self.grep, delta);
     }
 
     pub fn node_detail(&self, i: usize, offset_detail: usize) -> Table {
@@ -126,29 +125,13 @@ impl RipGrep {
         format!("{search_term} --json -A {after_context} -B {before_context} {folder}")
     }
 
-    fn args(&self, after_context: usize, before_context: usize) -> String {
-        let (search_term, folder) = (&self.search_term, &self.folder);
-        format!("{search_term} --json -A {after_context} -B {before_context} {folder}")
+    fn args(&self, after_context: usize, before_context: usize, file: String) -> String {
+        let search_term = &self.search_term;
+        format!("{search_term} --json -A {after_context} -B {before_context} {file}")
     }
 
-    /*
-    // fn run_immutable(&self, after_context: usize, before_context: usize) -> String {
-    // fn run_immutable(&self, after_context: usize, before_context: usize) -> Vec<String> {
-    fn run_immutable(&self, after_context: usize, before_context: usize) -> Vec<&str> {
-        let args = self.args(after_context, before_context);
-        match Self::launch_rg(args) {
-            Some(res) => {
-                res.split("\n").collect::<Vec<&str>>()
-            },
-            None => {
-                vec![]
-            }
-        }
-    }
-    */
-
-    fn run_immutable(&self, after_context: usize, before_context: usize) -> String {
-        let args = self.args(after_context, before_context);
+    fn run_immutable(&self, after_context: usize, before_context: usize, file: String) -> String {
+        let args = self.args(after_context, before_context, file);
         Self::launch_rg(args).unwrap()
     }
 

--- a/src/rip_grep/mod.rs
+++ b/src/rip_grep/mod.rs
@@ -11,16 +11,54 @@ mod nodes;
 pub struct RipGrep {
     search_term: String,
     pub search_term_buffer: String,
-    pub nodes: Nodes,
     after_context: usize,
     before_context: usize,
     folder: String,
 }
 
-impl RipGrep {
+pub struct Explorer {
+    pub nodes: Nodes,
+    pub grep: RipGrep,
+}
+
+impl Explorer {
+    pub fn new(search_term: String, folder: String) -> Self {
+        let mut grep = RipGrep::new(search_term, folder);
+        let nodes = grep.run();
+        Self {
+            nodes, grep,
+        }
+    }
+
+    pub fn run_wrapper(&mut self) {
+        if self.grep.search_term != self.grep.search_term_buffer {
+            self.nodes = self.grep.run();
+        }
+    }
+
     pub fn get_file_name_matches(&self) -> String{
         self.nodes.0.iter().fold("".to_string(), |res, n| res + " " + &n.file_name()).trim().to_string()
     }
+
+    pub fn update_context(&mut self, i: usize, delta: isize) {
+        let n: &mut Node = self.nodes.0.get_mut(i).unwrap();
+        // n.update_context(&self, delta);
+        n.update_context();
+    }
+
+    pub fn node_detail(&self, i: usize, offset_detail: usize) -> Table {
+        match self.nodes.0.get(i) {
+            Some(n) => n.detail(offset_detail),
+            None => Table::new(vec![])
+        }
+    }
+
+    pub fn get_node(&self, i: usize) -> &Node {
+        self.nodes.0.get(i).expect("Must have a node")
+    }
+}
+
+impl RipGrep {
     pub fn new(search_term: String, folder: String) -> Self {
         let after_context = 1;
         let before_context = 1;
@@ -31,13 +69,13 @@ impl RipGrep {
         // let data_raw = Self::launch_rg(format!("{} --json -A {} -B {}", &search_term, after_context, before_context));
         match data_raw {
             Some(data_raw) => Self {
-                nodes: Nodes::new(data_raw.split("\n").collect::<Vec<&str>>(), after_context, before_context),
+                // nodes: Nodes::new(data_raw.split("\n").collect::<Vec<&str>>(), after_context, before_context),
                 search_term_buffer: search_term.clone(),
                 search_term,
                 after_context, before_context, folder,
             },
             None => Self {
-                nodes: Nodes::new(vec![], after_context, before_context),
+                // nodes: Nodes::new(vec![], after_context, before_context),
                 search_term_buffer: search_term.clone(),
                 search_term,
                 after_context, before_context, folder,
@@ -45,43 +83,8 @@ impl RipGrep {
         }
     }
 
-    pub fn update_context(&mut self, i: usize, delta: isize) {
-    // pub fn update_context(self, i: usize, delta: isize) {
-        // let mut node = self.nodes.0.get(i).unwrap();
-        // let node: &mut Node = self.nodes.0.get(i).unwrap();
-
-        // let node: &mut Node = self.nodes.0.get(i).unwrap();
-
-        // let node: &mut Node = node.unwrap();
-        /*
-        match node {
-            Some(&mut n) => {
-                n.update_context(self, delta)
-            },
-            None => {}
-        }
-        */
-        // node.update_context(delta)
-
-
-        // self.nodes.0.get_mut(i).unwrap().update_context(&self, delta);
-
-
-        // self.nodes.0.get_mut
-
-
-
-
-        // self.nodes.0.get_mut(i).unwrap().update_context(self, delta);
-        let n: &mut Node = self.nodes.0.get_mut(i).unwrap();
-        n.update_context(&self, delta);
-
-        // let ns = &mut self.nodes.0;
-        /*
-        let ns = &mut self.nodes.0;
-        let n = ns.get_mut(i).unwrap();
-        n.update_context(self, delta)
-        */
+    pub fn get_params(&self) -> (String, String, String, String) {
+        (self.search_term.clone(), self.after_context.to_string(), self.before_context.to_string(), self.folder.clone())
     }
 
     pub fn decrease_context(&mut self) {
@@ -118,23 +121,6 @@ impl RipGrep {
         Some(Self::strip_trailing_newline(s).to_string())
     }
 
-    pub fn node_detail(&self, i: usize, offset_detail: usize) -> Table {
-        match self.nodes.0.get(i) {
-            Some(n) => n.detail(offset_detail),
-            None => Table::new(vec![])
-        }
-    }
-
-    pub fn get_node(&self, i: usize) -> &Node {
-        self.nodes.0.get(i).expect("Must have a node")
-    }
-
-    pub fn run_wrapper(&mut self) {
-        if self.search_term != self.search_term_buffer {
-            self.run();
-        }
-    }
-
     fn rg_args(&self) -> String {
         let (search_term, after_context, before_context, folder) = (&self.search_term, &self.after_context, &self.before_context, &self.folder);
         format!("{search_term} --json -A {after_context} -B {before_context} {folder}")
@@ -166,17 +152,17 @@ impl RipGrep {
         Self::launch_rg(args).unwrap()
     }
 
-    fn run(&mut self) {
+    fn run(&mut self) -> Nodes {
         self.search_term = self.search_term_buffer.clone();
         let args = self.rg_args();
         let res = Self::launch_rg(args);
         match res {
             Some(res) => {
                 let res = res.split("\n").collect::<Vec<&str>>();
-                self.nodes = Nodes::new(res, self.after_context, self.before_context);
+                Nodes::new(res, self.after_context.clone(), self.before_context.clone())
             },
             None => {
-                self.nodes = Nodes::new(vec![], self.after_context, self.before_context)
+                Nodes::new(vec![], self.after_context.clone(), self.before_context.clone())
             }
         }
     }
@@ -204,6 +190,14 @@ impl Display for RipGrep {
     fn fmt(&self, f: &mut Formatter) -> FmtResult {
         let (search_term, after_context, before_context, folder) = (&self.search_term, &self.after_context, &self.before_context, &self.folder);
         write!(f, "rg {search_term} --json -A {after_context} -B {before_context} {folder}")
+    }
+}
+
+impl Display for Explorer {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        let (search_term, after_context, before_context, folder) = self.grep.get_params();
+        write!(f, "{}", self.grep)
+        // write!(f, "rg {search_term} --json -A {after_context} -B {before_context} {folder}")
     }
 }
 

--- a/src/rip_grep/mod.rs
+++ b/src/rip_grep/mod.rs
@@ -31,13 +31,13 @@ impl RipGrep {
         // let data_raw = Self::launch_rg(format!("{} --json -A {} -B {}", &search_term, after_context, before_context));
         match data_raw {
             Some(data_raw) => Self {
-                nodes: Nodes::new(data_raw.split("\n").collect::<Vec<&str>>()),
+                nodes: Nodes::new(data_raw.split("\n").collect::<Vec<&str>>(), after_context, before_context),
                 search_term_buffer: search_term.clone(),
                 search_term,
                 after_context, before_context, folder,
             },
             None => Self {
-                nodes: Nodes::new(vec![]),
+                nodes: Nodes::new(vec![], after_context, before_context),
                 search_term_buffer: search_term.clone(),
                 search_term,
                 after_context, before_context, folder,
@@ -107,10 +107,10 @@ impl RipGrep {
         match res {
             Some(res) => {
                 let res = res.split("\n").collect::<Vec<&str>>();
-                self.nodes = Nodes::new(res);
+                self.nodes = Nodes::new(res, *after_context, *before_context);
             },
             None => {
-                self.nodes = Nodes::new(vec![])
+                self.nodes = Nodes::new(vec![], *after_context, *before_context)
             }
         }
     }

--- a/src/rip_grep/mod.rs
+++ b/src/rip_grep/mod.rs
@@ -45,6 +45,45 @@ impl RipGrep {
         }
     }
 
+    pub fn update_context(&mut self, i: usize, delta: isize) {
+    // pub fn update_context(self, i: usize, delta: isize) {
+        // let mut node = self.nodes.0.get(i).unwrap();
+        // let node: &mut Node = self.nodes.0.get(i).unwrap();
+
+        // let node: &mut Node = self.nodes.0.get(i).unwrap();
+
+        // let node: &mut Node = node.unwrap();
+        /*
+        match node {
+            Some(&mut n) => {
+                n.update_context(self, delta)
+            },
+            None => {}
+        }
+        */
+        // node.update_context(delta)
+
+
+        // self.nodes.0.get_mut(i).unwrap().update_context(&self, delta);
+
+
+        // self.nodes.0.get_mut
+
+
+
+
+        // self.nodes.0.get_mut(i).unwrap().update_context(self, delta);
+        let n: &mut Node = self.nodes.0.get_mut(i).unwrap();
+        n.update_context(&self, delta);
+
+        // let ns = &mut self.nodes.0;
+        /*
+        let ns = &mut self.nodes.0;
+        let n = ns.get_mut(i).unwrap();
+        n.update_context(self, delta)
+        */
+    }
+
     pub fn decrease_context(&mut self) {
         if self.after_context > 0 { self.after_context -= 1; }
         if self.before_context > 0 { self.before_context -= 1; }
@@ -99,6 +138,32 @@ impl RipGrep {
     fn rg_args(&self) -> String {
         let (search_term, after_context, before_context, folder) = (&self.search_term, &self.after_context, &self.before_context, &self.folder);
         format!("{search_term} --json -A {after_context} -B {before_context} {folder}")
+    }
+
+    fn args(&self, after_context: usize, before_context: usize) -> String {
+        let (search_term, folder) = (&self.search_term, &self.folder);
+        format!("{search_term} --json -A {after_context} -B {before_context} {folder}")
+    }
+
+    /*
+    // fn run_immutable(&self, after_context: usize, before_context: usize) -> String {
+    // fn run_immutable(&self, after_context: usize, before_context: usize) -> Vec<String> {
+    fn run_immutable(&self, after_context: usize, before_context: usize) -> Vec<&str> {
+        let args = self.args(after_context, before_context);
+        match Self::launch_rg(args) {
+            Some(res) => {
+                res.split("\n").collect::<Vec<&str>>()
+            },
+            None => {
+                vec![]
+            }
+        }
+    }
+    */
+
+    fn run_immutable(&self, after_context: usize, before_context: usize) -> String {
+        let args = self.args(after_context, before_context);
+        Self::launch_rg(args).unwrap()
     }
 
     fn run(&mut self) {

--- a/src/rip_grep/nodes/mod.rs
+++ b/src/rip_grep/nodes/mod.rs
@@ -16,7 +16,7 @@ struct AuxType {
 pub struct Nodes(pub Vec<Node>);
 
 impl Nodes {
-    pub fn new(data_raw: Vec<&str>) -> Self {
+    pub fn new(data_raw: Vec<&str>, after_context: usize, before_context: usize) -> Self {
         let mut v: Nodes = Nodes { 0: vec![]};
         let mut aux_vecs: Vec<(&str, Type)> = vec![];
 
@@ -28,7 +28,7 @@ impl Nodes {
                 },
                 Type::end => {
                     aux_vecs.push((d, t.r#type));
-                    let n: Node = Node::new(aux_vecs);
+                    let n: Node = Node::new(aux_vecs, after_context, before_context);
                     v.0.push(n);
                     aux_vecs = vec![];
                 }

--- a/src/rip_grep/nodes/node/mod.rs
+++ b/src/rip_grep/nodes/node/mod.rs
@@ -4,7 +4,7 @@ use serde_json::Result;
 
 // Cell::from(Spans::from(vec![Span::styled("My", Style::default().fg(Color::Yellow)), Span::raw(" text"),])),
 use tui::widgets::{ Cell, Row, Table, };
-use crate::rip_grep::RipGrep;
+use crate::rip_grep::{ Explorer, RipGrep };
 use crate::rip_grep::nodes::AuxType;
 
 pub mod r#type;
@@ -36,28 +36,30 @@ impl Node {
         */
     // }
 
-    // pub fn update_context(&mut self, rip_grep: &RipGrep, delta: isize) {
-    pub fn update_context(&mut self) {
-        /*
-        self.after_context += delta as usize;
-        self.before_context += delta as usize;
-        let output = rip_grep.run_immutable(self.after_context, self.before_context);
-        // match output.split("\n").collect() {
+    pub fn update_context(&mut self, rip_grep: &RipGrep, delta: isize) {
+        if delta > 0 {
+            self.after_context += delta as usize;
+            self.before_context += delta as usize;
+        } else {
+            let delta: usize = delta.wrapping_abs() as usize;
+            // let delta: usize = delta.abs() as usize;
+            if self.before_context > 0 { self.before_context -= delta; }
+            if self.after_context > 0 { self.after_context -= delta; }
+            // self.after_context -= delta;
+        }
+        // panic!("OH LA LA");
+        let output = rip_grep.run_immutable(self.after_context, self.before_context, self.file_name());
         self.r#match = vec![];
         let output = output.split("\n").collect::<Vec<&str>>();
         for d in output {
             let t = Self::parse_type(d).expect("Error parsing type at first level. Expected begin, match, end, context or summary");
             match t.r#type {
-                // Type::r#match => {
                 Type::r#match | Type::context => {
-                    // self.r#match.push((d, t.r#type))
                     self.r#match.push(Self::parse_subnode_match(d).expect("match expected").data)
                 },
                 _ => {}
             }
         }
-        */
-        todo!();
 
     }
     fn parse_type(d: &str) -> Result<AuxType> {

--- a/src/rip_grep/nodes/node/mod.rs
+++ b/src/rip_grep/nodes/node/mod.rs
@@ -17,13 +17,15 @@ pub struct Node {
     // context: Vec<Context>, // Option<Data>,
     r#match: Vec<Match>,
     end: Data,
+    after_context: usize,
+    before_context: usize,
 }
 
 impl Node {
     pub fn file_name(&self) -> String {
         self.begin.path.text.clone()
     }
-    pub fn new(data_raw: Vec<(&str, Type)>) -> Self {
+    pub fn new(data_raw: Vec<(&str, Type)>, after_context: usize, before_context: usize) -> Self {
         // todo!(); // XXX Use todo! macro to left a function without implementation, so beautiful :D
         let mut begin: Option<Begin> = None;
         let mut r#match: Vec<Match> = vec![];
@@ -53,6 +55,7 @@ impl Node {
             begin: begin.unwrap(),
             r#match,
             end: end.unwrap(),
+            after_context, before_context,
         }
     }
     fn parse_subnode_begin(d: &str) -> Result<SubnodeBegin> {

--- a/src/rip_grep/nodes/node/mod.rs
+++ b/src/rip_grep/nodes/node/mod.rs
@@ -25,9 +25,6 @@ pub struct Node {
 
 impl Node {
     // pub fn update_context(&mut self, rip_grep: &RipGrep, delta: isize) {
-    pub fn update_context(&mut self, rip_grep: &RipGrep, delta: isize) {
-        self.after_context += delta as usize;
-        self.before_context += delta as usize;
         /*
         if delta < 0 {
             self.after_context += delta;
@@ -37,7 +34,13 @@ impl Node {
             self.before_context += delta as usize;
         }
         */
+    // }
 
+    // pub fn update_context(&mut self, rip_grep: &RipGrep, delta: isize) {
+    pub fn update_context(&mut self) {
+        /*
+        self.after_context += delta as usize;
+        self.before_context += delta as usize;
         let output = rip_grep.run_immutable(self.after_context, self.before_context);
         // match output.split("\n").collect() {
         self.r#match = vec![];
@@ -50,14 +53,11 @@ impl Node {
                     // self.r#match.push((d, t.r#type))
                     self.r#match.push(Self::parse_subnode_match(d).expect("match expected").data)
                 },
-                /*
-                Type::context => {
-                    self.r#match.push((d, t.r#type))
-                },
-                */
                 _ => {}
             }
         }
+        */
+        todo!();
 
     }
     fn parse_type(d: &str) -> Result<AuxType> {

--- a/src/ui/edit.rs
+++ b/src/ui/edit.rs
@@ -11,7 +11,7 @@ use tui::{
 };
 
 use crate::ui::{App, InputMode};
-use crate::rip_grep::RipGrep;
+use crate::rip_grep::{ Explorer, RipGrep };
 
 
 pub fn render_edit<'a>(rip_grep_command: &'a RipGrep, chunk: Rect, input_mode: InputMode) -> (Paragraph<'a>, Paragraph<'a>, Vec<Rect>) {
@@ -51,7 +51,7 @@ pub fn render_edit<'a>(rip_grep_command: &'a RipGrep, chunk: Rect, input_mode: I
     (input, home, edit_chunks)
 }
 
-pub fn action_edit(rip_grep: &mut RipGrep, app: &mut App, key: KeyEvent) {
+pub fn action_edit(explorer: &mut Explorer, app: &mut App, key: KeyEvent) {
     match app.get_input_mode() {
         InputMode::Normal => {
             match key.code {
@@ -61,8 +61,8 @@ pub fn action_edit(rip_grep: &mut RipGrep, app: &mut App, key: KeyEvent) {
         },
         InputMode::Editing => {
             match key.code {
-                KeyCode::Char(c) => { rip_grep.search_term_buffer.push(c); },
-                KeyCode::Backspace => { rip_grep.search_term_buffer.pop(); }
+                KeyCode::Char(c) => { explorer.grep.search_term_buffer.push(c); },
+                KeyCode::Backspace => { explorer.grep.search_term_buffer.pop(); }
                 _ => {}
             }
         }

--- a/src/ui/nodes.rs
+++ b/src/ui/nodes.rs
@@ -10,10 +10,10 @@ use tui::{
 };
 
 use crate::ui::NodeTabSelected;
-use crate::rip_grep::RipGrep;
+use crate::rip_grep::Explorer;
 use crate::ui::{App, InputMode};
 
-pub fn render_nodes<'a>(node_list_state: &ListState, rip_grep: &'a RipGrep, app: &App) -> (List<'a>, Table<'a>) {
+pub fn render_nodes<'a>(node_list_state: &ListState, explorer: &'a Explorer, app: &App) -> (List<'a>, Table<'a>) {
     let folder_filter = app.folder_filter.clone();
     let selected_node_tab = &app.selected_node_tab;
     let (style_list, style_detail) = match selected_node_tab {
@@ -26,8 +26,8 @@ pub fn render_nodes<'a>(node_list_state: &ListState, rip_grep: &'a RipGrep, app:
         .title(format!("Filter: '{folder_filter}'"))
         .border_type(BorderType::Plain);
 
-    // let items: Vec<ListItem> = rip_grep.nodes.filtered_nodes(folder_filter)
-    let items: Vec<ListItem> = rip_grep.nodes.filtered_nodes(folder_filter)
+    // let items: Vec<ListItem> = explorer.nodes.filtered_nodes(folder_filter)
+    let items: Vec<ListItem> = explorer.nodes.filtered_nodes(folder_filter)
         .into_iter()
         .map(|node| {
             ListItem::new(Spans::from(vec![Span::styled(
@@ -44,9 +44,9 @@ pub fn render_nodes<'a>(node_list_state: &ListState, rip_grep: &'a RipGrep, app:
             .add_modifier(Modifier::BOLD),
     );
 
-    let detail_title = rip_grep.get_node(node_list_state.selected().expect("there is always a selected node"));
+    let detail_title = explorer.get_node(node_list_state.selected().expect("there is always a selected node"));
 
-    let node_detail = rip_grep.node_detail(node_list_state.selected().expect("there is always a selected node"), app.offset_detail)
+    let node_detail = explorer.node_detail(node_list_state.selected().expect("there is always a selected node"), app.offset_detail)
         .header(Row::new(vec![
             Cell::from(Span::styled(
                 format!(" {}", detail_title.file_name()),
@@ -67,7 +67,7 @@ pub fn render_nodes<'a>(node_list_state: &ListState, rip_grep: &'a RipGrep, app:
     (list, node_detail)
 }
 
-pub fn action_nodes(rip_grep: &mut RipGrep, app: &mut App, key: KeyEvent, node_list_state: &mut ListState) {
+pub fn action_nodes(explorer: &mut Explorer, app: &mut App, key: KeyEvent, node_list_state: &mut ListState) {
     match app.get_input_mode() {
         InputMode::Normal => {
             match key.code {
@@ -84,14 +84,14 @@ pub fn action_nodes(rip_grep: &mut RipGrep, app: &mut App, key: KeyEvent, node_l
         }
     }
     match key.code {
-        // KeyCode::Left => { rip_grep.decrease_context(); },
-        KeyCode::Left => { rip_grep.update_context(node_list_state.selected().unwrap(), -1); },
-        KeyCode::Right => { rip_grep.increase_context(); },
+        // KeyCode::Left => { explorer.decrease_context(); },
+        KeyCode::Left => { explorer.update_context(node_list_state.selected().unwrap(), -1); },
+        KeyCode::Right => { explorer.update_context(node_list_state.selected().unwrap(), 1); },
         KeyCode::Down => {
             match app.selected_node_tab {
                 NodeTabSelected::FileList => {
                     if let Some(selected) = node_list_state.selected() {
-                        let amount_nodes = rip_grep.nodes.filtered_nodes(app.folder_filter.clone()).len();
+                        let amount_nodes = explorer.nodes.filtered_nodes(app.folder_filter.clone()).len();
                         if selected >= amount_nodes - 1 {
                             node_list_state.select(Some(0));
                         } else {
@@ -102,7 +102,7 @@ pub fn action_nodes(rip_grep: &mut RipGrep, app: &mut App, key: KeyEvent, node_l
                 }
                 NodeTabSelected::Detail => {
                     if let Some(selected) = node_list_state.selected() {
-                        if app.offset_detail < rip_grep.nodes.node_matches_count(selected) { app.offset_detail += 1; }
+                        if app.offset_detail < explorer.nodes.node_matches_count(selected) { app.offset_detail += 1; }
                     }
                 }
             }
@@ -111,7 +111,7 @@ pub fn action_nodes(rip_grep: &mut RipGrep, app: &mut App, key: KeyEvent, node_l
             match app.selected_node_tab {
                 NodeTabSelected::FileList => {
                     if let Some(selected) = node_list_state.selected() {
-                        let amount_nodes = rip_grep.nodes.filtered_nodes(app.folder_filter.clone()).len();
+                        let amount_nodes = explorer.nodes.filtered_nodes(app.folder_filter.clone()).len();
                         if selected > 0 {
                             node_list_state.select(Some(selected - 1));
                         } else {

--- a/src/ui/nodes.rs
+++ b/src/ui/nodes.rs
@@ -84,7 +84,8 @@ pub fn action_nodes(rip_grep: &mut RipGrep, app: &mut App, key: KeyEvent, node_l
         }
     }
     match key.code {
-        KeyCode::Left => { rip_grep.decrease_context(); },
+        // KeyCode::Left => { rip_grep.decrease_context(); },
+        KeyCode::Left => { rip_grep.update_context(node_list_state.selected().unwrap(), -1); },
         KeyCode::Right => { rip_grep.increase_context(); },
         KeyCode::Down => {
             match app.selected_node_tab {

--- a/src/ui/sub_search.rs
+++ b/src/ui/sub_search.rs
@@ -13,7 +13,7 @@ use tui::{
 };
 
 use crate::ui::{App, InputMode};
-use crate::wrapper::rip_grep_wrapper;
+use crate::wrapper::explorer_wrapper;
 
 pub fn render_sub_search<'a>(_rip_grep_command: String, subchild_search: String) -> Paragraph<'a> {
     let sub_search = Paragraph::new(vec![
@@ -42,7 +42,7 @@ pub fn action_sub_search(terminal: &mut Terminal<CrosstermBackend<Stdout>>, file
         },
         InputMode::Editing => {
             match key.code {
-                KeyCode::Enter => { rip_grep_wrapper(terminal, app.subchild_search.clone(), file_name_matches)?; app.set_input_mode(InputMode::Normal); }
+                KeyCode::Enter => { explorer_wrapper(terminal, app.subchild_search.clone(), file_name_matches)?; app.set_input_mode(InputMode::Normal); }
                 KeyCode::Char(c) => { app.subchild_search.push(c); }
                 KeyCode::Backspace => { app.subchild_search.pop(); },
                 _ => {}

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -15,7 +15,7 @@ use crate::ui::sub_search::{render_sub_search, action_sub_search};
 use crate::ui::edit::render_edit;
 use crate::ui::nodes::render_nodes;
 use crate::ui::home::render_home;
-use crate::rip_grep::RipGrep;
+use crate::rip_grep::Explorer;
 
 #[derive(Error, Debug)]
 pub enum Error {
@@ -55,9 +55,9 @@ fn selection_menu_handler(key_code: KeyCode) -> Option <MenuItem> {
 }
 use std::io::Stdout;
 
- // pub fn rip_grep_wrapper(terminal: Terminal<B>) {
-pub fn rip_grep_wrapper(terminal: &mut Terminal<CrosstermBackend<Stdout>>, search_term: String, folders: String) -> Result<(), Box<dyn std::error::Error>> {
-    let mut rip_grep = RipGrep::new(search_term, folders); // TODO Create default
+ // pub fn explorer(terminal: Terminal<B>) {
+pub fn explorer_wrapper(terminal: &mut Terminal<CrosstermBackend<Stdout>>, search_term: String, folders: String) -> Result<(), Box<dyn std::error::Error>> {
+    let mut explorer = Explorer::new(search_term, folders); // TODO Create default
     let mut app = ui::App::default();
     let mut active_menu_item = MenuItem::Home;
     let mut node_list_state = ListState::default();
@@ -66,7 +66,7 @@ pub fn rip_grep_wrapper(terminal: &mut Terminal<CrosstermBackend<Stdout>>, searc
 
     loop {
         terminal.draw(|rect| {
-            let rip_grep = &mut rip_grep;
+            let explorer = &mut explorer;
             let chunks = ui::get_layout_chunks(rect.size());
 
             let status_bar = ui::draw_status_bar(app.get_input_mode());
@@ -75,10 +75,10 @@ pub fn rip_grep_wrapper(terminal: &mut Terminal<CrosstermBackend<Stdout>>, searc
 
             rect.render_widget(tabs, chunks[0]);
             match active_menu_item {
-                MenuItem::Home => rect.render_widget(render_home(rip_grep.to_string()), chunks[1]),
+                MenuItem::Home => rect.render_widget(render_home(explorer.to_string()), chunks[1]),
                 MenuItem::Nodes => {
-                    rip_grep.run_wrapper();
-                    if rip_grep.nodes.len() == 0{
+                    explorer.run_wrapper();
+                    if explorer.nodes.len() == 0{
                         // TODO: Put a message saying no results
                     } else {
                         let nodes_chunks = Layout::default()
@@ -87,19 +87,19 @@ pub fn rip_grep_wrapper(terminal: &mut Terminal<CrosstermBackend<Stdout>>, searc
                                 [Constraint::Percentage(20), Constraint::Percentage(80)].as_ref(),
                             )
                             .split(chunks[1]);
-                        let (left, right) = render_nodes(&node_list_state, &rip_grep, &app);
+                        let (left, right) = render_nodes(&node_list_state, &explorer, &app);
                         rect.render_stateful_widget(left, nodes_chunks[0], &mut node_list_state);
                         rect.render_widget(right, nodes_chunks[1]);
                     }
                 },
                 MenuItem::Edit => {
-                    let (first, second, edit_chunks) = render_edit(&rip_grep, chunks[1], app.get_input_mode());
+                    let (first, second, edit_chunks) = render_edit(&explorer.grep, chunks[1], app.get_input_mode());
                     rect.render_widget(first, edit_chunks[0]);
                     rect.render_widget(second, edit_chunks[1]);
                     match app.get_input_mode() {
                         ui::InputMode::Editing => { 
                             rect.set_cursor(
-                                edit_chunks[0].x + rip_grep.search_term_buffer.len() as u16 + 1,
+                                edit_chunks[0].x + explorer.grep.search_term_buffer.len() as u16 + 1,
                                 edit_chunks[0].y + 1,
                             )
 
@@ -107,7 +107,7 @@ pub fn rip_grep_wrapper(terminal: &mut Terminal<CrosstermBackend<Stdout>>, searc
                         _ => {},
                     }
                 },
-                MenuItem::SubSearch => rect.render_widget(render_sub_search(rip_grep.to_string(), app.subchild_search.to_string()), chunks[1]),
+                MenuItem::SubSearch => rect.render_widget(render_sub_search(explorer.to_string(), app.subchild_search.to_string()), chunks[1]),
             }
             rect.render_widget(status_bar, chunks[2]);
         })?;
@@ -137,13 +137,13 @@ pub fn rip_grep_wrapper(terminal: &mut Terminal<CrosstermBackend<Stdout>>, searc
             }
             match active_menu_item {
                 MenuItem::Edit => {
-                    action_edit(&mut rip_grep, &mut app, key);
+                    action_edit(&mut explorer, &mut app, key);
                 },
                 MenuItem::Nodes => {
-                    action_nodes(&mut rip_grep, &mut app, key, &mut node_list_state);
+                    action_nodes(&mut explorer, &mut app, key, &mut node_list_state);
                 },
                 MenuItem::SubSearch => {
-                    action_sub_search(terminal, rip_grep.get_file_name_matches(), &mut app, key)?;
+                    action_sub_search(terminal, explorer.get_file_name_matches(), &mut app, key)?;
                 },
                 _ => {
                     match key.code {


### PR DESCRIPTION
This PR solves #1 but it is in a draft state because the code is not compiling right now.

When left or right arrow is pressed on `nodes` tab, the code created on this branch will launch a `rg` instance on the selected file. That's the main idea.

The struct is roughly this:

```
struct RipGrep {
  ...
  nodes: Nodes
  ...
};
struct Nodes (pub Vec<Node>);
pub struct Node {
    begin: Begin,
    r#match: Vec<Match>,
    end: Data,
    after_context: usize,
    before_context: usize,
}

```

RipGrep struct has a function to perform the search, I'm calling this function but passing as file argument to `rg` the selected file. With `rg` output, a new function will find the selected file in `nodes: Vec<Node>` and will get the selected `Node` and here comes the problem: the selected `Node` will *mutate* and here is the compiler error that has being bugging me for days. 

Why it is so difficult to mutate the selected node that is part of the RipGrep Vec<Node> field? Is my data structure wrong? Is there a better approach?

I am trying other approaches on my local computer to solve the problem: try to find another path to mutate the selected Node. But I always end up with an error like this one (following screen shot is the result of building the app on the branch of this PR)

![image](https://user-images.githubusercontent.com/3003032/213344172-dbe25a51-6423-472b-9b39-a608d78bc0ce.png)

Any help will be appreciated here.
